### PR TITLE
Fixed typo in naver_endic_crawler call

### DIFF
--- a/endic_main.py
+++ b/endic_main.py
@@ -3,7 +3,7 @@ import naver_endic_parse as parse
 import naver_endic_crawler as crawl
 
 if len(sys.argv) > 1:
-    results = naver_endic_crawler(sys.argv[1])
+    results = crawl.naver_endic_crawler(sys.argv[1])
 else:
     word = input()
     results = crawl.naver_endic_crawler(word)


### PR DESCRIPTION
Changed naver_endic_crawler -> crawl.naver_endic_crawler on line 6 of endic_main.py

Without that, when I pass input, it crashes with a traceback that naver_endic_crawler is undefined.